### PR TITLE
Example 10 typo "userInfo.username" instead "userInfo.name"

### DIFF
--- a/10-use-reducer/Readme.md
+++ b/10-use-reducer/Readme.md
@@ -30,7 +30,7 @@ export const MyComponent = () => {
   return (
     <>
       <h3>
-        {userInfo.username} {userInfo.lastname}
+        {userInfo.name} {userInfo.lastname}
       </h3>
       <EditUsername name={userInfo.name} onChange={(name) => setInfo({
         ...userInfo,
@@ -92,7 +92,7 @@ export const MyComponent = () => {
   return (
     <>
       <h3>
--        {userInfo.username} {userInfo.lastname}
+-        {userInfo.name} {userInfo.lastname}
 +        {reducer.name} {reducer.lastname}
       </h3>
 -      <EditUsername name={userInfo.name} onChange={(name) => setInfo({


### PR DESCRIPTION
Fixed typo userInfo.username (it should be userInfo.name) in first steps of Readme.md.